### PR TITLE
Replace link to cheat sheet mug

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@
 
 + <https://beyondgrep.com/documentation/>
 
-+ [Regex Cheat Sheet Mug](https://moderngeek.co/products/regex-cheat-sheet-mug?_pos=4&_sid=c36ae64eb&_ss=r)
++ [Regex Cheat Sheet Mug](https://www.moderngeekware.com/products/regex-cheat-sheet-mug)


### PR DESCRIPTION
The store linked in the README has shut down.  This updates the link to an alternate [regex cheat-sheet mug](https://www.moderngeekware.com/products/regex-cheat-sheet-mug) with similar information.